### PR TITLE
Changes to create pet prob matrix using native space images

### DIFF
--- a/esm/create_pet_probability_matrix.py
+++ b/esm/create_pet_probability_matrix.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+
+import sys
+import glob
+import re
+sys.path.insert(0,'..')
+import ESM_utils as esm
+import pandas as pd
+from argparse import ArgumentParser
+
+def get_sub_ids(parametric_images):
+    subs = []
+    for path in parametric_images:
+        sub=path.split("/")[-1].split("_")[0].split("-")[1]
+        subs.append(sub)
+    return subs
+
+def get_dkt_labels():
+    df = pd.read_csv("../../data/atlases/dst_labels.csv", header=None)
+    cols = list(df[1][0:78])
+    left_dkt_roi_cols = ['Left%s' % x for x in cols[0:39]]
+    right_dkt_roi_cols = ['Right%s' % x for x in cols[39:78]]
+    dkt_roi_cols = left_dkt_roi_cols + right_dkt_roi_cols
+    return dkt_roi_cols
+
+
+def create_prob_matrix(parametric_images,
+                       atlas_images,
+                       ref,
+                       output_name,
+                       dataset,
+                       visit
+                       ):
+     output = esm.Prepare_PET_Data(files_in=parametric_images,
+                                   atlases=atlas_images,
+                                   ref=ref,
+                                   orig_prob_method_matlab=True,
+                                   save_matrix="return",
+                                   );
+     # remove the L & R cerebellum
+     output = pd.read_csv("PET_data_roi_data.csv")
+     output = output.drop(["roi_79", "roi_80"], axis=1)
+     subs = get_sub_ids(parametric_images)
+     dkt_roi_cols = get_dkt_labels()
+     output.index = subs
+     output.columns = dkt_roi_cols
+     output.to_csv("../../data/" + dataset + "/pet_probability_matrices/" + output_name + "_" + visit + ".csv")
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("--parametric_files_dir",
+                        help="Please pass the files directory containing the parametric PET images")
+    parser.add_argument("--visit",
+			help="")
+    parser.add_argument("--dkt_atlas_dir",
+                        help="")
+    parser.add_argument("--ref_region_dir",
+                        default=None,
+                        help="Path to dir containing reference region images")
+    parser.add_argument("--ref_regions",
+                        nargs="+",
+                        type=int,
+                        default=None, 
+                        help="Integer values for reference region labels")
+    parser.add_argument("--output_name",
+                        help="Please provide filename for PET probability matrix.")
+    parser.add_argument("--dataset",
+                        help="ADNI or DIAN")
+    results = parser.parse_args()
+
+    parametric_files_dir = results.parametric_files_dir
+    visit = results.visit
+    dkt_atlas_dir = results.dkt_atlas_dir
+    ref_region_dir = results.ref_region_dir
+    ref_regions = results.ref_regions
+    dataset = results.dataset
+    output_name = results.output_name
+
+    if ref_region_dir is None and ref_regions is None: 
+        raise IOError("Please provide either a ref region files dir or list of ref region labels")
+    else: 
+        if ref_region_dir is not None: 
+            ref = sorted(glob.glob(ref_region_dir))
+        elif ref_regions is not None: 
+            ref = ref_regions
+        
+    parametric_images = sorted(glob.glob(parametric_files_dir))
+    dkt_atlas_images = sorted(glob.glob(dkt_atlas_dir))
+
+    #print(parametric_files_dir)
+
+    create_prob_matrix(parametric_images,
+                       dkt_atlas_images,
+                       ref,
+                       output_name,
+                       dataset,
+                       visit)
+
+if __name__ == "__main__":
+    main()
+
+
+
+
+
+
+
+
+
+

--- a/esm/run_create_pet_prob_matrix_DIAN_PUP_test_int.sh
+++ b/esm/run_create_pet_prob_matrix_DIAN_PUP_test_int.sh
@@ -1,0 +1,8 @@
+#!/bin/bash 
+
+python3.6 create_pet_probability_matrix.py --parametric_files_dir "/home/users/llevitis/ace_mount/ace_home/DIAN_PUP_output/sub-*/ses-v00/*pib*.nii.gz" \
+  --dkt_atlas_dir "/home/users/llevitis/ace_mount/ace_home/DIAN_PUP_output/sub-*/ses-v00/*esm-regions_space-T1w.nii.gz" \
+  --ref_regions 79 80 \
+  --output_name "DIAN_PUP_coregistered_voxelwise_ecdf_orig_method_test_int" \
+  --dataset "DIAN" \
+  --visit "v00"

--- a/esm/voxelwise_pet_prob_yasser2016.m
+++ b/esm/voxelwise_pet_prob_yasser2016.m
@@ -1,0 +1,7 @@
+function mi4d_ecdf = voxelwise_pet_prob_yasser2016(mi4d, refz) 
+
+cut_inf = prctile(refz, 5)
+cut_sup = prctile(refz, 95)
+[MAXs] = bootstrp(20000, @max, refz(refz >= cut_inf & refz <= cut_sup)); 
+parmhat = evfit(double(MAXs));
+mi4d_ecdf = evcdf(mi4d, parmhat(1), parmhat(2));


### PR DESCRIPTION
- [ ] Added change to `Plot_Probabilites` to accept `cmap` value. 
- [ ] `Prepare_PET_Data` now accepts a dir containing atlases in native space + either a dir pointing to ref region images in native space or a list of ints specifying the ref region labels 
- [ ] `create_pet_probability matrix.py` is a wrapper for the `Prepare_PET_Data` function and by default uses Yasser's original prob metric
- [ ] `run_create_pet_prob_matrix_DIAN_PUP_test_int.sh` is an example bash script launching the python script 
- [ ] `voxelwise_pet_prob_yasser2016.m` contains the function Yasser originally used to generate the prob metric